### PR TITLE
Typo in uses statement for chef-install

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ jobs:
     - name: Check out code
       uses: actions/checkout@master
     - name: install chef
-      uses: actionshub/chef-installl@master
+      uses: actionshub/chef-install@master
  ```
 
 ## Envrionment Variables


### PR DESCRIPTION
# Description

Typo in uses statement for chef-install (was pointing to `actionshub/chef-installl` which doesn't exist).

## Issues Resolved

Fixed typo.

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
