### PR TITLE
update @actions/core to v1.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/actionshub/chef-install#readme",
   "dependencies": {
-    "@actions/core": "^1.2.0",
+    "@actions/core": "^1.2.6",
     "@actions/exec": "^1.0.2",
     "os": "^0.1.1"
   }


### PR DESCRIPTION
# Description

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

## Issues Resolved

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
