### PR TITLE
Moves away from Omnitruck to Chef Community + adds License param needed for commercial endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ There is support for Macos, Linux and Windows with this action
 
 ## Usage
 
-Use the default settings to install [chef-workstation](https://www.chef.sh/docs/chef-workstation/about/) from the stable channel
+Use the default settings to install [chef-workstation](https://docs.chef.io/workstation/) from the stable channel
 
 ```yaml
 name: delivery
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@master
+      uses: actions/checkout@main
     - name: install chef
       uses: actionshub/chef-install@main
       with:
@@ -52,9 +52,9 @@ We support the following parameters
 | name         | default           | description                                                                            |
 | ------------ | ----------------- | -------------------------------------------------------------------------------------- |
 | channel      | stable            | Chef Channel to install, stable or current                                             |
-| project      | chef-workstation  | Which product to install, see <https://docs.chef.io/install_omnibus.html> for the list |
+| project      | chef-workstation  | Which product to install, see <https://docs.chef.io/chef_install_script/> for the list |
 | version      | latest            | version to install                                                                     |
-| omnitruckUrl | omnitruck.chef.io | which Omnitruck to use, default is Chef Official                                       |
+| chefDownloadUrl | chefdownload-community.chef.io | which Chef Download API to use, default is Chef Community                                       |
 | license | '' | license key, required if using https://docs.chef.io/download/commercial/ |
 
-By Changing the omnitruck Url you can also install Cinc projects
+By Changing the chefDownloadUrl you can also install Cinc projects

--- a/README.md
+++ b/README.md
@@ -55,6 +55,6 @@ We support the following parameters
 | project      | chef-workstation  | Which product to install, see <https://docs.chef.io/chef_install_script/> for the list |
 | version      | latest            | version to install                                                                     |
 | chefDownloadUrl | chefdownload-community.chef.io | which Chef Download API to use, default is Chef Community                                       |
-| license | '' | license key, required if using https://docs.chef.io/download/commercial/ |
+| license |  | license key, required if using https://docs.chef.io/download/commercial/ |
 
 By Changing the chefDownloadUrl you can also install Cinc projects

--- a/README.md
+++ b/README.md
@@ -55,5 +55,6 @@ We support the following parameters
 | project      | chef-workstation  | Which product to install, see <https://docs.chef.io/install_omnibus.html> for the list |
 | version      | latest            | version to install                                                                     |
 | omnitruckUrl | omnitruck.chef.io | which Omnitruck to use, default is Chef Official                                       |
+| license | '' | license key, required if using https://docs.chef.io/download/commercial/ |
 
 By Changing the omnitruck Url you can also install Cinc projects

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,8 @@ inputs:
     required: false
   omnitruckUrl:
     description: 'Omnitruck base url'
+  license:
+    description: 'license key, required if using https://docs.chef.io/download/commercial/'
     required: false
     default: 'omnitruck.chef.io'
   windowsPath:

--- a/action.yml
+++ b/action.yml
@@ -14,12 +14,13 @@ inputs:
   version:
     description: 'version to install, default is latest'
     required: false
-  omnitruckUrl:
-    description: 'Omnitruck base url'
+  chefDownloadUrl:
+    description: 'Chef download base url, defaults to https://docs.chef.io/download/community/'
+    required: false
+    default: 'chefdownload-community.chef.io'
   license:
     description: 'license key, required if using https://docs.chef.io/download/commercial/'
     required: false
-    default: 'omnitruck.chef.io'
   windowsPath:
     description: 'Path to the root of the chef install. Windows Only'
     required: false

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ async function main() {
     const channel = core.getInput('channel') || 'stable';
     const project = core.getInput('project') || 'chef-workstation';
     const version = core.getInput('version');
-    const omnitruckUrl = core.getInput('omnitruckUrl') || 'omnitruck.chef.io';
+    const chefDownloadUrl = core.getInput('chefDownloadUrl') || 'chefdownload-community.chef.io';
 
     const license = core.getInput('license');
     const licenseParam = license ? `?license_id=${license}` : '';
@@ -27,7 +27,7 @@ async function main() {
       else {
         versionParam = ''
       }
-      await exec.exec(`curl -L https://${omnitruckUrl}/install.sh${licenseParam} -o chefDownload.sh`)
+      await exec.exec(`curl -L https://${chefDownloadUrl}/install.sh${licenseParam} -o chefDownload.sh`)
       await exec.exec(`sudo chmod +x chefDownload.sh`)
       await exec.exec(`sudo ./chefDownload.sh ${channelParam} ${projectParam} ${versionParam}`)
       await exec.exec(`rm -f chefDownload.sh`)
@@ -44,7 +44,7 @@ async function main() {
       else {
         versionParam = ''
       }
-      await exec.exec(`powershell.exe -command ". { iwr -useb https://${omnitruckUrl}/install.ps1${licenseParam} } | iex; install ${channelParam} ${projectParam} ${versionParam}"`)
+      await exec.exec(`powershell.exe -command ". { iwr -useb https://${chefDownloadUrl}/install.ps1${licenseParam} } | iex; install ${channelParam} ${projectParam} ${versionParam}"`)
       core.addPath(`${windowsPath}\\bin`)
     }
 

--- a/index.js
+++ b/index.js
@@ -9,6 +9,10 @@ async function main() {
     const project = core.getInput('project') || 'chef-workstation';
     const version = core.getInput('version');
     const omnitruckUrl = core.getInput('omnitruckUrl') || 'omnitruck.chef.io';
+
+    const license = core.getInput('license');
+    const licenseParam = license ? `?license_id=${license}` : '';
+
     // This tool has intimate knowledge of the os
     // as Windows and Linux/MacOS run different installers
     // so we will check what OS and run appropriately
@@ -23,7 +27,7 @@ async function main() {
       else {
         versionParam = ''
       }
-      await exec.exec(`curl -L https://${omnitruckUrl}/install.sh -o chefDownload.sh`)
+      await exec.exec(`curl -L https://${omnitruckUrl}/install.sh${licenseParam} -o chefDownload.sh`)
       await exec.exec(`sudo chmod +x chefDownload.sh`)
       await exec.exec(`sudo ./chefDownload.sh ${channelParam} ${projectParam} ${versionParam}`)
       await exec.exec(`rm -f chefDownload.sh`)
@@ -40,7 +44,7 @@ async function main() {
       else {
         versionParam = ''
       }
-      await exec.exec(`powershell.exe -command ". { iwr -useb https://${omnitruckUrl}/install.ps1 } | iex; install ${channelParam} ${projectParam} ${versionParam}"`)
+      await exec.exec(`powershell.exe -command ". { iwr -useb https://${omnitruckUrl}/install.ps1${licenseParam} } | iex; install ${channelParam} ${projectParam} ${versionParam}"`)
       core.addPath(`${windowsPath}\\bin`)
     }
 


### PR DESCRIPTION
# Description

As Omnitruck is scheduled to reach its End of Life (EOL) by mid-2025. I'm pushing this PR to move away from Omnitruck endpoint, defaulting to [Chef Community endpoint](https://docs.chef.io/download/community/) and adding the license param required for [Chef Commercial endpoint ](https://docs.chef.io/download/commercial/)

## Issues Resolved

- Omnitruck deprecation

## Check List

- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
