### PR TITLE
feat: support Chef community and Cinc installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,15 @@
 
 A Github Action to install Chef on a build agent
 
-Note you will need to accept the Chef license, you can find more information at <https://docs.chef.io/chef_license.html>
+Chef installs now use the [Chef Community download API](https://docs.chef.io/download/community/),
+which requires a free `license_id`. Cinc installs do not require a license and continue to work
+through the Cinc omnibus endpoint.
 
 There is support for Macos, Linux and Windows with this action
 
 ## Usage
 
-Use the default settings to install [chef-workstation](https://www.chef.sh/docs/chef-workstation/about/) from the stable channel
+Use the default settings to install [chef-workstation](https://docs.chef.io/workstation/) from the stable channel
 
 ```yaml
 name: delivery
@@ -26,9 +28,11 @@ jobs:
       uses: actions/checkout@master
     - name: install chef
       uses: actionshub/chef-install@main
+      with:
+        license: ${{ secrets.CHEF_LICENSE_ID }}
 ```
 
-Install [inspec](https://www.inspec.io/) from the current channel
+Install [inspec](https://www.inspec.io/) from the commercial API on the current channel
 
 ```yaml
 
@@ -41,15 +45,35 @@ jobs:
     - name: install chef
       uses: actionshub/chef-install@main
       with:
+        license: ${{ secrets.CHEF_LICENSE_ID }}
+        chefDownloadUrl: chefdownload-commercial.chef.io
         channel: current
         project: inspec
 ```
 
-### Version pinning
+Install Cinc Workstation from the Cinc omnibus endpoint without a license:
 
-By default, `chef-workstation` installs version **21.6.497** — the last release that ships
-test-kitchen 2.x. Versions 21.7.524 and later bundle test-kitchen 3.x which contains
-breaking changes.
+```yaml
+
+jobs:
+  delivery:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@master
+    - name: install cinc
+      uses: actionshub/chef-install@main
+      with:
+        project: cinc-workstation
+        omnitruckUrl: omnitruck.cinc.sh
+```
+
+The installed Cinc packages are Chef-compatible. If you need direct package downloads instead of
+the install script, Cinc also publishes plain packages at <https://cinc.sh/download/>.
+
+### Version selection
+
+By default, `chef-workstation` installs the latest available version.
 
 To opt in to the latest release:
 
@@ -73,11 +97,18 @@ To pin to a specific version:
 
 We support the following parameters
 
-| name         | default                            | description                                                                            |
-| ------------ | ---------------------------------- | -------------------------------------------------------------------------------------- |
-| channel      | stable                             | Chef Channel to install, stable or current                                             |
-| project      | chef-workstation                   | Which product to install, see <https://docs.chef.io/install_omnibus.html> for the list |
-| version      | 21.6.497 (for chef-workstation)    | Version to install. Set to `latest` for the newest release.                            |
-| omnitruckUrl | omnitruck.chef.io                  | which Omnitruck to use, default is Chef Official                                       |
+| name            | default                      | description                                                                                         |
+| --------------- | ---------------------------- | --------------------------------------------------------------------------------------------------- |
+| channel         | stable                       | Chef channel to install, stable or current                                                          |
+| project         | chef-workstation             | Which product to install, see <https://docs.chef.io/chef_install_script/> for Chef project names   |
+| version         | latest (for chef-workstation) | Version to install. Set to `latest` for the newest release.                                        |
+| chefDownloadUrl | chefdownload-community.chef.io | Chef download API host. Defaults to the Chef Community API.                                        |
+| license         |                              | Chef Downloads license ID. Required for Chef Community/Commercial downloads. Not used for Cinc.    |
+| omnitruckUrl    |                              | Deprecated compatibility input for omnitruck hosts. Set this for Cinc, for example `omnitruck.cinc.sh`. |
+| windowsPath     | `C:\opscode\chef-workstation\` | Root install path used for the Windows PATH update step. Override this for products installed elsewhere. |
 
-By Changing the omnitruck Url you can also install Cinc projects
+`omnitruckUrl` takes precedence over `chefDownloadUrl`, which preserves compatibility for existing
+omnitruck-based installs while allowing Chef downloads to use the community API by default.
+
+When using the default Chef Community API, `channel` must remain `stable`. Use
+`chefdownload-commercial.chef.io` if you need the `current` channel for Chef packages.

--- a/README.md
+++ b/README.md
@@ -5,15 +5,16 @@
 
 A Github Action to install Chef on a build agent
 
-Chef installs now use the [Chef Community download API](https://docs.chef.io/download/community/),
-which requires a free `license_id`. Cinc installs do not require a license and continue to work
-through the Cinc omnibus endpoint.
+By default this action installs Cinc from `omnitruck.cinc.sh`. Chef installs use the
+[Chef Community download API](https://docs.chef.io/download/community/) or the Chef commercial API
+when you provide a `license_id`.
 
 There is support for Macos, Linux and Windows with this action
 
 ## Usage
 
-Use the default settings to install [chef-workstation](https://docs.chef.io/workstation/) from the stable channel
+Use the default settings to install [Cinc Workstation](https://cinc.sh/start/workstation/) from
+the Cinc omnibus endpoint
 
 ```yaml
 name: delivery
@@ -26,10 +27,25 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@master
+    - name: install cinc
+      uses: actionshub/chef-install@main
+```
+
+Install [Chef Workstation](https://docs.chef.io/workstation/) from the Chef Community API
+
+```yaml
+
+jobs:
+  delivery:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@master
     - name: install chef
       uses: actionshub/chef-install@main
       with:
         license: ${{ secrets.CHEF_LICENSE_ID }}
+        project: chef-workstation
 ```
 
 Install [inspec](https://www.inspec.io/) from the commercial API on the current channel
@@ -51,7 +67,7 @@ jobs:
         project: inspec
 ```
 
-Install Cinc Workstation from the Cinc omnibus endpoint without a license:
+Install Cinc Workstation explicitly:
 
 ```yaml
 
@@ -65,7 +81,6 @@ jobs:
       uses: actionshub/chef-install@main
       with:
         project: cinc-workstation
-        omnitruckUrl: omnitruck.cinc.sh
 ```
 
 The installed Cinc packages are Chef-compatible. If you need direct package downloads instead of
@@ -73,7 +88,7 @@ the install script, Cinc also publishes plain packages at <https://cinc.sh/downl
 
 ### Version selection
 
-By default, `chef-workstation` installs the latest available version.
+By default, `cinc-workstation` installs the latest available version.
 
 To opt in to the latest release:
 
@@ -100,15 +115,22 @@ We support the following parameters
 | name            | default                      | description                                                                                         |
 | --------------- | ---------------------------- | --------------------------------------------------------------------------------------------------- |
 | channel         | stable                       | Chef channel to install, stable or current                                                          |
-| project         | chef-workstation             | Which product to install, see <https://docs.chef.io/chef_install_script/> for Chef project names   |
-| version         | latest (for chef-workstation) | Version to install. Set to `latest` for the newest release.                                        |
+| project         | cinc-workstation             | Which product to install, see <https://docs.chef.io/chef_install_script/> for Chef project names and <https://cinc.sh/start/> for Cinc products |
+| version         | latest (for workstation installs) | Version to install. Set to `latest` for the newest release.                                    |
 | chefDownloadUrl | chefdownload-community.chef.io | Chef download API host. Defaults to the Chef Community API.                                        |
 | license         |                              | Chef Downloads license ID. Required for Chef Community/Commercial downloads. Not used for Cinc.    |
-| omnitruckUrl    |                              | Deprecated compatibility input for omnitruck hosts. Set this for Cinc, for example `omnitruck.cinc.sh`. |
-| windowsPath     | `C:\opscode\chef-workstation\` | Root install path used for the Windows PATH update step. Override this for products installed elsewhere. |
+| omnitruckUrl    | omnitruck.cinc.sh            | Deprecated compatibility input for omnitruck hosts. Defaults to the Cinc omnibus endpoint.         |
+| windowsPath     | auto                         | Root install path used for the Windows PATH update step. Override this for products installed elsewhere. |
 
-`omnitruckUrl` takes precedence over `chefDownloadUrl`, which preserves compatibility for existing
-omnitruck-based installs while allowing Chef downloads to use the community API by default.
+When `license` is set, the action uses `chefDownloadUrl`. Without a `license`, the action uses
+`omnitruckUrl`, which defaults to Cinc.
 
 When using the default Chef Community API, `channel` must remain `stable`. Use
 `chefdownload-commercial.chef.io` if you need the `current` channel for Chef packages.
+
+For compatibility, Chef product names are mapped to their Cinc equivalents when installing from
+the default Cinc omnitruck endpoint:
+
+- `chef-workstation` becomes `cinc-workstation`
+- `inspec` becomes `cinc-auditor`
+- `chef` and `chef-client` become `cinc`

--- a/action.yml
+++ b/action.yml
@@ -52,12 +52,17 @@ runs:
         VERSION: ${{ inputs.version }}
         OMNITRUCK_URL: ${{ inputs.omnitruckUrl }}
       run: |
-        if (-not $env:VERSION -and $env:PROJECT -eq "chef-workstation") {
-          $env:VERSION = "latest"
+        $params = @{
+          channel = $env:CHANNEL
+          project = $env:PROJECT
         }
-        $vFlag = if ($env:VERSION) { "-version $env:VERSION" } else { "" }
+        if (-not $env:VERSION -and $env:PROJECT -eq "chef-workstation") {
+          $params["version"] = "latest"
+        } elseif ($env:VERSION) {
+          $params["version"] = $env:VERSION
+        }
         . { iwr -useb "https://$env:OMNITRUCK_URL/install.ps1" } | iex
-        install -channel $env:CHANNEL -project $env:PROJECT $vFlag
+        install @params
 
     - name: Add Chef to PATH (Windows)
       if: runner.os == 'Windows'

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,7 @@ runs:
       run: |
         set -euo pipefail
         INSTALL_PROJECT="$PROJECT"
+        SCRIPT_SUFFIX="install.sh"
         if [ -z "$LICENSE" ]; then
           case "$PROJECT" in
             chef-workstation)
@@ -70,13 +71,58 @@ runs:
             echo "The Chef Community API only supports the stable channel. Use chefdownload-commercial.chef.io or an omnitruck endpoint for current." >&2
             exit 1
           fi
-          SCRIPT_URL="https://${CHEF_DOWNLOAD_URL}/install.sh?license_id=${LICENSE}"
+          SCRIPT_URL="https://${CHEF_DOWNLOAD_URL}/${SCRIPT_SUFFIX}?license_id=${LICENSE}"
         else
-          SCRIPT_URL="https://${OMNITRUCK_URL}/install.sh"
+          if [ -z "$OMNITRUCK_URL" ]; then
+            echo "No install source configured. Set 'license' for Chef downloads or 'omnitruckUrl' for omnitruck-compatible installs." >&2
+            exit 1
+          fi
+          SCRIPT_URL="https://${OMNITRUCK_URL}/${SCRIPT_SUFFIX}"
         fi
 
-        curl -fsSL "$SCRIPT_URL" \
-          | sudo bash -s -- -c "${CHANNEL}" -P "${INSTALL_PROJECT}" ${VERSION_FLAG}
+        TEMP_SCRIPT="$(mktemp)"
+        TEMP_HEADERS="$(mktemp)"
+        cleanup() {
+          rm -f "$TEMP_SCRIPT" "$TEMP_HEADERS"
+        }
+        trap cleanup EXIT
+
+        CURL_INFO="$(curl --silent --show-error --location \
+          --dump-header "$TEMP_HEADERS" \
+          --output "$TEMP_SCRIPT" \
+          --write-out '%{http_code} %{url_effective}' \
+          "$SCRIPT_URL")"
+        HTTP_STATUS="${CURL_INFO%% *}"
+        EFFECTIVE_URL="${CURL_INFO#* }"
+
+        if [ "$HTTP_STATUS" != "200" ]; then
+          echo "Failed to download installer from $SCRIPT_URL (HTTP $HTTP_STATUS)." >&2
+          if [ -n "$LICENSE" ]; then
+            echo "Check that the supplied Chef license_id is valid for ${CHEF_DOWNLOAD_URL}." >&2
+          fi
+          exit 1
+        fi
+
+        case "$EFFECTIVE_URL" in
+          *"/${SCRIPT_SUFFIX}"* ) ;;
+          *)
+            echo "Installer download redirected to an unexpected URL: $EFFECTIVE_URL" >&2
+            if [ -n "$LICENSE" ]; then
+              echo "This usually means the supplied Chef license_id is missing or invalid." >&2
+            fi
+            exit 1
+            ;;
+        esac
+
+        if grep -Eiq '^[[:space:]]*<(!DOCTYPE|html)\b' "$TEMP_SCRIPT"; then
+          echo "Installer download returned HTML instead of a shell script: $EFFECTIVE_URL" >&2
+          if [ -n "$LICENSE" ]; then
+            echo "This usually means the supplied Chef license_id is missing or invalid." >&2
+          fi
+          exit 1
+        fi
+
+        sudo bash "$TEMP_SCRIPT" -c "${CHANNEL}" -P "${INSTALL_PROJECT}" ${VERSION_FLAG}
 
     - name: Install Chef (Windows)
       if: runner.os == 'Windows'
@@ -94,6 +140,7 @@ runs:
           channel = $env:CHANNEL
         }
         $installProject = $env:PROJECT
+        $scriptSuffix = "install.ps1"
         if (-not $env:LICENSE) {
           switch ($env:PROJECT) {
             "chef-workstation" { $installProject = "cinc-workstation" }
@@ -113,12 +160,59 @@ runs:
           if ($env:CHEF_DOWNLOAD_URL -eq "chefdownload-community.chef.io" -and $env:CHANNEL -ne "stable") {
             throw "The Chef Community API only supports the stable channel. Use chefdownload-commercial.chef.io or an omnitruck endpoint for current."
           }
-          $scriptUrl = "https://$env:CHEF_DOWNLOAD_URL/install.ps1?license_id=$($env:LICENSE)"
+          $scriptUrl = "https://$env:CHEF_DOWNLOAD_URL/$scriptSuffix?license_id=$($env:LICENSE)"
         } else {
-          $scriptUrl = "https://$env:OMNITRUCK_URL/install.ps1"
+          if (-not $env:OMNITRUCK_URL) {
+            throw "No install source configured. Set 'license' for Chef downloads or 'omnitruckUrl' for omnitruck-compatible installs."
+          }
+          $scriptUrl = "https://$env:OMNITRUCK_URL/$scriptSuffix"
         }
 
-        . { iwr -useb $scriptUrl } | iex
+        $scriptPath = Join-Path $env:RUNNER_TEMP "chef-install-script.ps1"
+        try {
+          $response = Invoke-WebRequest -UseBasicParsing -Uri $scriptUrl -MaximumRedirection 5 -OutFile $scriptPath -PassThru -ErrorAction Stop
+        } catch {
+          $statusCode = $null
+          if ($_.Exception.Response -and $_.Exception.Response.StatusCode) {
+            $statusCode = $_.Exception.Response.StatusCode.value__
+          }
+          if ($statusCode) {
+            $message = "Failed to download installer from $scriptUrl (HTTP $statusCode)."
+          } else {
+            $message = "Failed to download installer from $scriptUrl."
+          }
+          if ($env:LICENSE) {
+            $message += " Check that the supplied Chef license_id is valid for $($env:CHEF_DOWNLOAD_URL)."
+          }
+          throw $message
+        }
+
+        $effectiveUrl = $response.BaseResponse.ResponseUri.AbsoluteUri
+        if ($response.StatusCode -ne 200) {
+          $message = "Failed to download installer from $scriptUrl (HTTP $($response.StatusCode))."
+          if ($env:LICENSE) {
+            $message += " Check that the supplied Chef license_id is valid for $($env:CHEF_DOWNLOAD_URL)."
+          }
+          throw $message
+        }
+        if ($effectiveUrl -notlike "*/$scriptSuffix*") {
+          $message = "Installer download redirected to an unexpected URL: $effectiveUrl"
+          if ($env:LICENSE) {
+            $message += ". This usually means the supplied Chef license_id is missing or invalid."
+          }
+          throw $message
+        }
+
+        $scriptContent = Get-Content -Path $scriptPath -Raw
+        if ($scriptContent -match '^\s*<(?:!DOCTYPE|html)\b') {
+          $message = "Installer download returned HTML instead of a PowerShell script: $effectiveUrl"
+          if ($env:LICENSE) {
+            $message += ". This usually means the supplied Chef license_id is missing or invalid."
+          }
+          throw $message
+        }
+
+        . $scriptPath
         install @params
         if ($env:WINDOWS_PATH) {
           $installRoot = $env:WINDOWS_PATH

--- a/action.yml
+++ b/action.yml
@@ -10,9 +10,9 @@ inputs:
   project:
     description: 'Which Chef or Cinc project to install'
     required: false
-    default: 'chef-workstation'
+    default: 'cinc-workstation'
   version:
-    description: 'Version to install. Defaults to latest for chef-workstation'
+    description: 'Version to install. Defaults to latest for workstation installs'
     required: false
   chefDownloadUrl:
     description: 'Chef download base url'
@@ -24,11 +24,11 @@ inputs:
   omnitruckUrl:
     description: 'Deprecated: Omnitruck base url. Use for Cinc or other omnitruck-compatible endpoints.'
     required: false
-    default: ''
+    default: 'omnitruck.cinc.sh'
   windowsPath:
     description: 'Path to the root of the install on Windows. Override this for non-default products such as Cinc.'
     required: false
-    default: 'C:\opscode\chef-workstation\'
+    default: ''
 runs:
   using: composite
   steps:
@@ -44,28 +44,39 @@ runs:
         OMNITRUCK_URL: ${{ inputs.omnitruckUrl }}
       run: |
         set -euo pipefail
-        if [ -z "$VERSION" ] && [ "$PROJECT" = "chef-workstation" ]; then
+        INSTALL_PROJECT="$PROJECT"
+        if [ -z "$LICENSE" ]; then
+          case "$PROJECT" in
+            chef-workstation)
+              INSTALL_PROJECT="cinc-workstation"
+              ;;
+            inspec)
+              INSTALL_PROJECT="cinc-auditor"
+              ;;
+            chef|chef-client)
+              INSTALL_PROJECT="cinc"
+              ;;
+          esac
+        fi
+
+        if [ -z "$VERSION" ] && { [ "$INSTALL_PROJECT" = "chef-workstation" ] || [ "$INSTALL_PROJECT" = "cinc-workstation" ]; }; then
           VERSION="latest"
         fi
         VERSION_FLAG=""
         [ -n "$VERSION" ] && VERSION_FLAG="-v ${VERSION}"
 
-        if [ -n "$OMNITRUCK_URL" ]; then
-          SCRIPT_URL="https://${OMNITRUCK_URL}/install.sh"
-        else
-          if [ -z "$LICENSE" ]; then
-            echo "The 'license' input is required when using Chef Community/Commercial downloads." >&2
-            exit 1
-          fi
+        if [ -n "$LICENSE" ]; then
           if [ "$CHEF_DOWNLOAD_URL" = "chefdownload-community.chef.io" ] && [ "$CHANNEL" != "stable" ]; then
             echo "The Chef Community API only supports the stable channel. Use chefdownload-commercial.chef.io or an omnitruck endpoint for current." >&2
             exit 1
           fi
           SCRIPT_URL="https://${CHEF_DOWNLOAD_URL}/install.sh?license_id=${LICENSE}"
+        else
+          SCRIPT_URL="https://${OMNITRUCK_URL}/install.sh"
         fi
 
         curl -fsSL "$SCRIPT_URL" \
-          | sudo bash -s -- -c "${CHANNEL}" -P "${PROJECT}" ${VERSION_FLAG}
+          | sudo bash -s -- -c "${CHANNEL}" -P "${INSTALL_PROJECT}" ${VERSION_FLAG}
 
     - name: Install Chef (Windows)
       if: runner.os == 'Windows'
@@ -77,38 +88,44 @@ runs:
         CHEF_DOWNLOAD_URL: ${{ inputs.chefDownloadUrl }}
         LICENSE: ${{ inputs.license }}
         OMNITRUCK_URL: ${{ inputs.omnitruckUrl }}
+        WINDOWS_PATH: ${{ inputs.windowsPath }}
       run: |
         $params = @{
           channel = $env:CHANNEL
-          project = $env:PROJECT
         }
-        if (-not $env:VERSION -and $env:PROJECT -eq "chef-workstation") {
+        $installProject = $env:PROJECT
+        if (-not $env:LICENSE) {
+          switch ($env:PROJECT) {
+            "chef-workstation" { $installProject = "cinc-workstation" }
+            "inspec" { $installProject = "cinc-auditor" }
+            { $_ -in @("chef", "chef-client") } { $installProject = "cinc" }
+          }
+        }
+        $params["project"] = $installProject
+
+        if (-not $env:VERSION -and $installProject -in @("chef-workstation", "cinc-workstation")) {
           $params["version"] = "latest"
         } elseif ($env:VERSION) {
           $params["version"] = $env:VERSION
         }
 
-        if ($env:OMNITRUCK_URL) {
-          $scriptUrl = "https://$env:OMNITRUCK_URL/install.ps1"
-        } else {
-          if (-not $env:LICENSE) {
-            throw "The 'license' input is required when using Chef Community/Commercial downloads."
-          }
+        if ($env:LICENSE) {
           if ($env:CHEF_DOWNLOAD_URL -eq "chefdownload-community.chef.io" -and $env:CHANNEL -ne "stable") {
             throw "The Chef Community API only supports the stable channel. Use chefdownload-commercial.chef.io or an omnitruck endpoint for current."
           }
           $scriptUrl = "https://$env:CHEF_DOWNLOAD_URL/install.ps1?license_id=$($env:LICENSE)"
+        } else {
+          $scriptUrl = "https://$env:OMNITRUCK_URL/install.ps1"
         }
 
         . { iwr -useb $scriptUrl } | iex
         install @params
-
-    - name: Add Chef to PATH (Windows)
-      if: runner.os == 'Windows'
-      shell: bash
-      env:
-        WINDOWS_PATH: ${{ inputs.windowsPath }}
-      run: echo "${WINDOWS_PATH}bin" >> "$GITHUB_PATH"
+        if ($env:WINDOWS_PATH) {
+          $installRoot = $env:WINDOWS_PATH
+        } else {
+          $installRoot = "C:\opscode\$installProject\"
+        }
+        "$($installRoot)bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 branding:
   icon: 'download'
   color: 'red'

--- a/action.yml
+++ b/action.yml
@@ -1,25 +1,32 @@
 ---
 name: 'actionshub-chef-install'
 author: 'Jason Field'
-description: 'Installs Chef on your linux build agent with ease'
+description: 'Installs Chef or Cinc on your build agent with ease'
 inputs:
   channel:
     description: 'Chef Channel to install, stable or current'
     required: false
     default: 'stable'
   project:
-    description: 'which chef project to install, chef-workstation or chefdk'
+    description: 'Which Chef or Cinc project to install'
     required: false
     default: 'chef-workstation'
   version:
     description: 'Version to install. Defaults to latest for chef-workstation'
     required: false
-  omnitruckUrl:
-    description: 'Omnitruck base url'
+  chefDownloadUrl:
+    description: 'Chef download base url'
     required: false
-    default: 'omnitruck.chef.io'
+    default: 'chefdownload-community.chef.io'
+  license:
+    description: 'Chef Downloads license ID. Required for Chef Community/Commercial downloads; not used for Cinc.'
+    required: false
+  omnitruckUrl:
+    description: 'Deprecated: Omnitruck base url. Use for Cinc or other omnitruck-compatible endpoints.'
+    required: false
+    default: ''
   windowsPath:
-    description: 'Path to the root of the chef install. Windows Only'
+    description: 'Path to the root of the install on Windows. Override this for non-default products such as Cinc.'
     required: false
     default: 'C:\opscode\chef-workstation\'
 runs:
@@ -32,15 +39,32 @@ runs:
         CHANNEL: ${{ inputs.channel }}
         PROJECT: ${{ inputs.project }}
         VERSION: ${{ inputs.version }}
+        CHEF_DOWNLOAD_URL: ${{ inputs.chefDownloadUrl }}
+        LICENSE: ${{ inputs.license }}
         OMNITRUCK_URL: ${{ inputs.omnitruckUrl }}
       run: |
-        set -o pipefail
+        set -euo pipefail
         if [ -z "$VERSION" ] && [ "$PROJECT" = "chef-workstation" ]; then
           VERSION="latest"
         fi
         VERSION_FLAG=""
         [ -n "$VERSION" ] && VERSION_FLAG="-v ${VERSION}"
-        curl -fsSL "https://${OMNITRUCK_URL}/install.sh" \
+
+        if [ -n "$OMNITRUCK_URL" ]; then
+          SCRIPT_URL="https://${OMNITRUCK_URL}/install.sh"
+        else
+          if [ -z "$LICENSE" ]; then
+            echo "The 'license' input is required when using Chef Community/Commercial downloads." >&2
+            exit 1
+          fi
+          if [ "$CHEF_DOWNLOAD_URL" = "chefdownload-community.chef.io" ] && [ "$CHANNEL" != "stable" ]; then
+            echo "The Chef Community API only supports the stable channel. Use chefdownload-commercial.chef.io or an omnitruck endpoint for current." >&2
+            exit 1
+          fi
+          SCRIPT_URL="https://${CHEF_DOWNLOAD_URL}/install.sh?license_id=${LICENSE}"
+        fi
+
+        curl -fsSL "$SCRIPT_URL" \
           | sudo bash -s -- -c "${CHANNEL}" -P "${PROJECT}" ${VERSION_FLAG}
 
     - name: Install Chef (Windows)
@@ -50,6 +74,8 @@ runs:
         CHANNEL: ${{ inputs.channel }}
         PROJECT: ${{ inputs.project }}
         VERSION: ${{ inputs.version }}
+        CHEF_DOWNLOAD_URL: ${{ inputs.chefDownloadUrl }}
+        LICENSE: ${{ inputs.license }}
         OMNITRUCK_URL: ${{ inputs.omnitruckUrl }}
       run: |
         $params = @{
@@ -61,7 +87,20 @@ runs:
         } elseif ($env:VERSION) {
           $params["version"] = $env:VERSION
         }
-        . { iwr -useb "https://$env:OMNITRUCK_URL/install.ps1" } | iex
+
+        if ($env:OMNITRUCK_URL) {
+          $scriptUrl = "https://$env:OMNITRUCK_URL/install.ps1"
+        } else {
+          if (-not $env:LICENSE) {
+            throw "The 'license' input is required when using Chef Community/Commercial downloads."
+          }
+          if ($env:CHEF_DOWNLOAD_URL -eq "chefdownload-community.chef.io" -and $env:CHANNEL -ne "stable") {
+            throw "The Chef Community API only supports the stable channel. Use chefdownload-commercial.chef.io or an omnitruck endpoint for current."
+          }
+          $scriptUrl = "https://$env:CHEF_DOWNLOAD_URL/install.ps1?license_id=$($env:LICENSE)"
+        }
+
+        . { iwr -useb $scriptUrl } | iex
         install @params
 
     - name: Add Chef to PATH (Windows)


### PR DESCRIPTION
## Summary

- default Chef installs to the Chef Community download API via a new chefDownloadUrl input
- add a license input for Chef Community/Commercial downloads
- keep omnitruckUrl as a compatibility override, which also preserves the Cinc install path
- document Cinc omnibus usage and clarify that Cinc packages do not require a license
- validate that the default Chef Community API is only used with the stable channel

## Why

Omnitruck is no longer the right default path for Chef installs, but this action still needs to support Cinc and avoid breaking existing omnitruck-based consumers. This keeps the newer Chef download flow as the default while preserving omnitruckUrl precedence for backwards compatibility and Cinc.

## Verification

- parsed action.yml with Ruby YAML
- ran git diff --check
- did not run the action on a live GitHub runner

## Notes

- Chef Community/Commercial downloads require a license_id
- Cinc installs continue to work through omnitruck.cinc.sh without a license
- direct Cinc package downloads remain available at https://cinc.sh/download/
- this follows the direction of upstream PR #35 while keeping the compatibility concern raised in review