### PR TITLE
feat: support Chef Community/Commercial download API with license input based on PR#35 and it's feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ There is support for Macos, Linux and Windows with this action
 
 ## Usage
 
-Use the default settings to install [chef-workstation](https://www.chef.sh/docs/chef-workstation/about/) from the stable channel
+Use the default settings to install [chef-workstation](https://docs.chef.io/workstation/) from the stable channel via Omnitruck
 
 ```yaml
 name: delivery
@@ -28,7 +28,7 @@ jobs:
       uses: actionshub/chef-install@main
 ```
 
-Install [inspec](https://www.inspec.io/) from the current channel
+Install [chef-workstation](https://docs.chef.io/workstation/) from the Chef Community download API
 
 ```yaml
 
@@ -37,10 +37,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@master
+      uses: actions/checkout@main
     - name: install chef
       uses: actionshub/chef-install@main
       with:
+        license: ${{ secrets.CHEF_LICENSE_ID }}
+        project: chef-workstation
+```
+
+Install [inspec](https://www.inspec.io/) from the Chef Commercial API on the current channel
+
+```yaml
+
+jobs:
+  delivery:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@main
+    - name: install chef
+      uses: actionshub/chef-install@main
+      with:
+        license: ${{ secrets.CHEF_LICENSE_ID }}
+        chefDownloadUrl: chefdownload-commercial.chef.io
         channel: current
         project: inspec
 ```
@@ -73,11 +92,16 @@ To pin to a specific version:
 
 We support the following parameters
 
-| name         | default                            | description                                                                            |
-| ------------ | ---------------------------------- | -------------------------------------------------------------------------------------- |
-| channel      | stable                             | Chef Channel to install, stable or current                                             |
-| project      | chef-workstation                   | Which product to install, see <https://docs.chef.io/install_omnibus.html> for the list |
-| version      | 21.6.497 (for chef-workstation)    | Version to install. Set to `latest` for the newest release.                            |
-| omnitruckUrl | omnitruck.chef.io                  | which Omnitruck to use, default is Chef Official                                       |
+| name            | default                          | description                                                                            |
+| --------------- | -------------------------------- | -------------------------------------------------------------------------------------- |
+| channel         | stable                           | Chef channel to install, stable or current                                             |
+| project         | chef-workstation                 | Which product to install, see <https://docs.chef.io/chef_install_script/> for the list |
+| version         | 21.6.497 (for chef-workstation)  | Version to install. Set to `latest` for the newest release.                            |
+| chefDownloadUrl | chefdownload-community.chef.io   | Chef download API host. Used when `license` is provided.                               |
+| license         |                                  | Chef license ID. Required for Chef Community/Commercial downloads.                     |
+| omnitruckUrl    | omnitruck.chef.io                | Omnitruck base url. Used when no `license` is provided.                                |
 
-By Changing the omnitruck Url you can also install Cinc projects
+When `license` is set, the action downloads the installer from `chefDownloadUrl`. Without a
+`license`, the action falls back to `omnitruckUrl` for backwards compatibility.
+
+By changing the `omnitruckUrl` you can also install Cinc projects (e.g. `omnitruck.cinc.sh`).

--- a/action.yml
+++ b/action.yml
@@ -14,8 +14,15 @@ inputs:
   version:
     description: 'Version to install. Defaults to latest for chef-workstation'
     required: false
+  chefDownloadUrl:
+    description: 'Chef download base url. Used when license is provided.'
+    required: false
+    default: 'chefdownload-community.chef.io'
+  license:
+    description: 'Chef license ID. Required for Chef Community/Commercial downloads.'
+    required: false
   omnitruckUrl:
-    description: 'Omnitruck base url'
+    description: 'Omnitruck base url. Used when no license is provided.'
     required: false
     default: 'omnitruck.chef.io'
   windowsPath:
@@ -32,6 +39,8 @@ runs:
         CHANNEL: ${{ inputs.channel }}
         PROJECT: ${{ inputs.project }}
         VERSION: ${{ inputs.version }}
+        CHEF_DOWNLOAD_URL: ${{ inputs.chefDownloadUrl }}
+        LICENSE: ${{ inputs.license }}
         OMNITRUCK_URL: ${{ inputs.omnitruckUrl }}
       run: |
         set -o pipefail
@@ -40,7 +49,12 @@ runs:
         fi
         VERSION_FLAG=""
         [ -n "$VERSION" ] && VERSION_FLAG="-v ${VERSION}"
-        curl -fsSL "https://${OMNITRUCK_URL}/install.sh" \
+        if [ -n "$LICENSE" ]; then
+          SCRIPT_URL="https://${CHEF_DOWNLOAD_URL}/install.sh?license_id=${LICENSE}"
+        else
+          SCRIPT_URL="https://${OMNITRUCK_URL}/install.sh"
+        fi
+        curl -fsSL "$SCRIPT_URL" \
           | sudo bash -s -- -c "${CHANNEL}" -P "${PROJECT}" ${VERSION_FLAG}
 
     - name: Install Chef (Windows)
@@ -50,13 +64,20 @@ runs:
         CHANNEL: ${{ inputs.channel }}
         PROJECT: ${{ inputs.project }}
         VERSION: ${{ inputs.version }}
+        CHEF_DOWNLOAD_URL: ${{ inputs.chefDownloadUrl }}
+        LICENSE: ${{ inputs.license }}
         OMNITRUCK_URL: ${{ inputs.omnitruckUrl }}
       run: |
         if (-not $env:VERSION -and $env:PROJECT -eq "chef-workstation") {
           $env:VERSION = "latest"
         }
         $vFlag = if ($env:VERSION) { "-version $env:VERSION" } else { "" }
-        . { iwr -useb "https://$env:OMNITRUCK_URL/install.ps1" } | iex
+        if ($env:LICENSE) {
+          $scriptUrl = "https://$env:CHEF_DOWNLOAD_URL/install.ps1?license_id=$($env:LICENSE)"
+        } else {
+          $scriptUrl = "https://$env:OMNITRUCK_URL/install.ps1"
+        }
+        . { iwr -useb $scriptUrl } | iex
         install -channel $env:CHANNEL -project $env:PROJECT $vFlag
 
     - name: Add Chef to PATH (Windows)


### PR DESCRIPTION
# Description

Add chefDownloadUrl and license inputs for the Chef download API while keeping omnitruckUrl for backwards compatibility. When license is provided the action uses chefDownloadUrl; otherwise it falls back to omnitruckUrl so existing consumers are unaffected.

Addresses feedback from actionshub/chef-install#35.

## Issues Resolved

the current date for commercial chef downloads of any version to use only [authenticated downloads](https://www.chef.io/blog/decoding-the-change-progress-chef-is-moving-to-licensed-downloads) is July 14, 2026. This adds that functionality

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
